### PR TITLE
Maintenance Plans full CRUD

### DIFF
--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -1,4 +1,5 @@
 // Import your components CSS files here.
 @import "alert";
 @import "avatar";
+@import "list";
 @import "navbar";

--- a/app/assets/stylesheets/components/_list.scss
+++ b/app/assets/stylesheets/components/_list.scss
@@ -1,0 +1,27 @@
+.list-el {
+  display: flex;
+  background-color: white;
+  border-bottom: 1px solid gray;
+  padding: 0 10px;
+  div {
+    min-width: 100px;
+    margin-right: 20px;
+  }
+}
+
+.list-subtask {
+  color: gray;
+}
+
+.list-task {
+  display: flex;
+  flex-direction: column;
+}
+
+.list-alert {
+  color: red;
+}
+
+.list-edit {
+  margin-top: 30px;
+}

--- a/app/controllers/maintenance_plans_controller.rb
+++ b/app/controllers/maintenance_plans_controller.rb
@@ -1,2 +1,86 @@
 class MaintenancePlansController < ApplicationController
+  before_action :set_plan, only: %i[edit update destroy]
+  before_action :set_vehicle
+
+  def index
+    populate_index
+    @plan = MaintenancePlan.new
+    @btn_txt = "Ajouter"
+  end
+
+  def create
+    @plan = MaintenancePlan.new(plan_params)
+    @plan.vehicle = @vehicle
+
+    if @plan.save
+      redirect_to vehicle_maintenance_plans_path(@vehicle)
+    else
+      @btn_txt = "Ajouter"
+      populate_index
+      render "maintenance_plans/index"
+    end
+  end
+
+  def edit
+    @btn_txt = 'Editer'
+    populate_index
+    render "maintenance_plans/index"
+  end
+
+  def update
+    @plan.vehicle = @vehicle
+    if @plan.update(plan_params)
+      redirect_to vehicle_maintenance_plans_path(@vehicle)
+    else
+      @btn_txt = "Editer"
+      populate_index
+      render "maintenance_plans/index"
+    end
+  end
+
+  def destroy
+    # remove links between the deleted MP and Operations
+    Operation.where(maintenance_plan_id: params[:id]).update_all(maintenance_plan_id: '')
+    @plan.destroy
+
+    redirect_to vehicle_maintenance_plans_path(@vehicle)
+  end
+
+  private
+
+  def set_plan
+    @plan = MaintenancePlan.find(params[:id])
+  end
+
+  def set_vehicle
+    @vehicle = Vehicle.find(params[:vehicle_id])
+  end
+
+  def plan_params
+    params.require(:maintenance_plan).permit(:task, :details, :interval_km, :interval_months)
+  end
+
+  def populate_index
+    sql = %{with last_ops as (select mp.id as mp_id
+                                    ,max(o.id) as last_id
+                              from   maintenance_plans mp
+                              left outer join operations o on mp.id = o.maintenance_plan_id
+                              where  mp.vehicle_id = #{params[:vehicle_id]}
+                              group by mp.id)
+            select mp.id as id
+                  ,mp.task as task
+                  ,mp.details as details
+                  ,mp.interval_km as int_km
+                  ,mp.interval_months as int_months
+                  ,mp.interval_km - (v.actual_km - coalesce(m.km, 0)) as next_km
+                  ,coalesce(m.date, v.purchase_date) + make_interval(months => mp.interval_months) as next_date
+            from   last_ops lo
+            join maintenance_plans mp on lo.mp_id = mp.id
+            join vehicles v on mp.vehicle_id = v.id
+            left outer join operations o on lo.last_id = o.id
+            left outer join maintenances m on o.maintenance_id = m.id
+            order by next_km}
+
+    @plans = ActiveRecord::Base.connection.exec_query(sql)
+  end
 end

--- a/app/models/maintenance_plan.rb
+++ b/app/models/maintenance_plan.rb
@@ -1,4 +1,6 @@
 class MaintenancePlan < ApplicationRecord
   belongs_to :vehicle
   has_many :operations
+
+  validates :task, :interval_km, :interval_months, presence: true
 end

--- a/app/views/maintenance_plans/_mp_edit.html.erb
+++ b/app/views/maintenance_plans/_mp_edit.html.erb
@@ -1,0 +1,8 @@
+<h3><%= "#{@btn_txt} la tâche" %></h3>
+<%= simple_form_for [@vehicle, @plan] do |f| %>
+  <%= f.input :task %>
+  <%= f.input :details %>
+  <%= f.input :interval_km %>
+  <%= f.input :interval_months %>
+  <%= f.submit "Save" %>
+<% end %>

--- a/app/views/maintenance_plans/_mp_edit.html.erb
+++ b/app/views/maintenance_plans/_mp_edit.html.erb
@@ -5,4 +5,5 @@
   <%= f.input :interval_km %>
   <%= f.input :interval_months %>
   <%= f.submit "Save" %>
+  <%= link_to "Cancel", vehicle_maintenance_plans_path %>
 <% end %>

--- a/app/views/maintenance_plans/index.html.erb
+++ b/app/views/maintenance_plans/index.html.erb
@@ -1,0 +1,37 @@
+<h2>Plan de maintenance</h2>
+<div class="container">
+  <div class="list-ops">
+    <div class="list-el"> <!--display flex-->
+      <div>Tâche</div>
+      <div>Intervale</div>
+      <div>Prochaine occurrence</div>
+    </div>
+    <% if @plans %>
+      <% @plans.each do |plan| %>
+        <div class="list-el"> <!--display flex-->
+          <div class="list-task">
+            <span><%= plan["task"] %></span>
+            <span class="list-subtask"><%= plan["details"] %></span>
+          </div>
+          <div>
+            <span><%= plan["int_km"] %></span>
+            <span><%= plan["int_months"] %></span>
+          </div>
+          <% next_class = "list-alert" if plan["next_km"] < 0 || plan["next_date"] < Time.now %>
+          <div class="<%= next_class %>">
+            <span><%= plan["next_km"] %></span>
+            </span><%= plan["next_date"].strftime("%d/%m/%Y") %></span>
+          </div>
+          <div>
+            <%= link_to "Edit", edit_vehicle_maintenance_plan_path(@vehicle, plan["id"]) %>
+             | 
+            <%= link_to "Del.", vehicle_maintenance_plan_path(@vehicle, plan["id"]), method: :delete, remote: true %>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+  <div class="list-edit">
+    <%= render "mp_edit" %>
+  </div>
+</div>

--- a/app/views/vehicles/show.html.erb
+++ b/app/views/vehicles/show.html.erb
@@ -14,4 +14,6 @@
 
 <%= link_to "Editer ce véhicule", edit_vehicle_path(@vehicle) %>
 <br>
+<%= link_to "Plan de maintenance", vehicle_maintenance_plans_path(@vehicle) %>
+<br>
 <%= link_to "Accueil", vehicles_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
     resources :invoices, except: %i[destroy]
     resources :vehicle_fuels, except: %i[show edit update]
     resources :refuels, except: %i[show edit update]
-    resources :maintenance_plans, except: %i[show]
+    resources :maintenance_plans, except: %i[show new]
     resources :maintenances, except: %i[show] do
       resources :operations, except: %i[show]
     end


### PR DESCRIPTION
Full CRUD for the maintenance plan.
**Index** and partial to **add** or **edit** a record are displayed on the same page.
On deletion, if the maintenance plan is linked to records in _Operations_, the MP id is removed from the table _Operations_ before _MP.destroy_ (a MP can be deleted, not the operations).

A link to the maintenance plan was added into the **vehicle#show**.

Layout and CSS have to be defined/update.