### PR TITLE
Maintenance and Operation full CRUD

### DIFF
--- a/app/controllers/maintenances_controller.rb
+++ b/app/controllers/maintenances_controller.rb
@@ -1,2 +1,69 @@
 class MaintenancesController < ApplicationController
+  before_action :set_maintenance, only: %i[show edit update destroy]
+  before_action :set_vehicle, only: %i[index create edit update]
+
+  def index
+    populate_index
+
+    @maintenance = Maintenance.new
+    @btn_txt = "Ajouter"
+  end
+
+  def create
+    @maintenance = Maintenance.new(maintenance_params)
+    @maintenance.vehicle_id = params[:vehicle_id]
+
+    if @maintenance.save
+      redirect_to vehicle_maintenance_operations_path(params[:vehicle_id], @maintenance)
+    else
+      @btn_txt = "Ajouter"
+      populate_index
+      render "maintenances/index"
+    end
+  end
+
+  def edit
+    @btn_txt = 'Editer'
+    populate_index
+    render "maintenances/index"
+  end
+
+  def update
+    @maintenance.vehicle_id = params[:vehicle_id]
+    if @maintenance.update(maintenance_params)
+      redirect_to vehicle_maintenances_path(params[:vehicle_id])
+    else
+      @btn_txt = "Editer"
+      populate_index
+      render "maintenances/index"
+    end
+  end
+
+  def destroy
+    @maintenance.destroy
+
+    redirect_to vehicle_maintenances_path(params[:vehicle_id])
+  end
+
+  private
+
+  def set_maintenance
+    @maintenance = Maintenance.find(params[:id])
+  end
+
+  def set_vehicle
+    @vehicle = Vehicle.find(params[:vehicle_id])
+  end
+
+  def maintenance_params
+    params.require(:maintenance).permit(:date, :km)
+  end
+
+  def populate_index
+    @maintenances = Maintenance.left_outer_joins(:operations)
+                               .select("maintenances.id, maintenances.date, maintenances.km, count(operations.id) as nb_ops")
+                               .where(vehicle_id: params[:vehicle_id])
+                               .group("maintenances.id")
+                               .order("maintenances.date DESC")
+  end
 end

--- a/app/controllers/maintenances_controller.rb
+++ b/app/controllers/maintenances_controller.rb
@@ -11,10 +11,10 @@ class MaintenancesController < ApplicationController
 
   def create
     @maintenance = Maintenance.new(maintenance_params)
-    @maintenance.vehicle_id = params[:vehicle_id]
+    @maintenance.vehicle = @vehicle
 
     if @maintenance.save
-      redirect_to vehicle_maintenance_operations_path(params[:vehicle_id], @maintenance)
+      redirect_to vehicle_maintenance_operations_path(@vehicle, @maintenance)
     else
       @btn_txt = "Ajouter"
       populate_index
@@ -29,9 +29,9 @@ class MaintenancesController < ApplicationController
   end
 
   def update
-    @maintenance.vehicle_id = params[:vehicle_id]
+    @maintenance.vehicle = @vehicle
     if @maintenance.update(maintenance_params)
-      redirect_to vehicle_maintenances_path(params[:vehicle_id])
+      redirect_to vehicle_maintenances_path(@vehicle)
     else
       @btn_txt = "Editer"
       populate_index

--- a/app/controllers/operations_controller.rb
+++ b/app/controllers/operations_controller.rb
@@ -12,11 +12,11 @@ class OperationsController < ApplicationController
 
   def create
     @operation = Operation.new(operation_params)
-    @operation.maintenance_id = params[:maintenance_id]
+    @operation.maintenance = @maintenance
     @operation.maintenance_plan_id = extract_mp_id
 
     if @operation.save
-      redirect_to vehicle_maintenance_operations_path(params[:vehicle_id], params[:maintenance_id])
+      redirect_to vehicle_maintenance_operations_path(@vehicle, @maintenance)
     else
       @btn_txt = "Ajouter"
       populate_index
@@ -33,7 +33,7 @@ class OperationsController < ApplicationController
   def update
     @operation.maintenance_plan_id = extract_mp_id
     if @operation.update(operation_params)
-      redirect_to vehicle_maintenance_operations_path(params[:vehicle_id], params[:maintenance_id])
+      redirect_to vehicle_maintenance_operations_path(@vehicle, @maintenance)
     else
       @btn_txt = "Editer"
       populate_index

--- a/app/controllers/operations_controller.rb
+++ b/app/controllers/operations_controller.rb
@@ -1,2 +1,78 @@
 class OperationsController < ApplicationController
+  before_action :set_operation, only: %i[show edit update destroy]
+  before_action :set_maintenance, only: %i[index create edit update]
+  before_action :set_vehicle, only: %i[index create edit update]
+
+  def index
+    populate_index
+
+    @operation = Operation.new
+    @btn_txt = "Ajouter"
+  end
+
+  def create
+    @operation = Operation.new(operation_params)
+    @operation.maintenance_id = params[:maintenance_id]
+    @operation.maintenance_plan_id = extract_mp_id
+
+    if @operation.save
+      redirect_to vehicle_maintenance_operations_path(params[:vehicle_id], params[:maintenance_id])
+    else
+      @btn_txt = "Ajouter"
+      populate_index
+      render "operations/index"
+    end
+  end
+
+  def edit
+    @btn_txt = 'Editer'
+    populate_index
+    render "operations/index"
+  end
+
+  def update
+    @operation.maintenance_plan_id = extract_mp_id
+    if @operation.update(operation_params)
+      redirect_to vehicle_maintenance_operations_path(params[:vehicle_id], params[:maintenance_id])
+    else
+      @btn_txt = "Editer"
+      populate_index
+      render "operations/index"
+    end
+  end
+
+  def destroy
+    @operation.destroy
+
+    redirect_to vehicle_maintenance_operations_path(params[:vehicle_id], params[:maintenance_id])
+  end
+
+  private
+
+  def set_operation
+    @operation = Operation.find(params[:id])
+  end
+
+  def set_maintenance
+    @maintenance = Maintenance.find(params[:maintenance_id])
+  end
+
+  def set_vehicle
+    @vehicle = Vehicle.find(params[:vehicle_id])
+  end
+
+  def operation_params
+    params.require(:operation).permit(:task, :details)
+  end
+
+  def populate_index
+    @maintenance = Maintenance.find(params[:maintenance_id])
+    @operations = Operation.where(maintenance_id: params[:maintenance_id])
+  end
+
+  def extract_mp_id
+    return if params[:operation][:maintenance_plan_id].empty?
+
+    JSON.parse(params[:operation][:maintenance_plan_id])["id"]
+  end
 end

--- a/app/javascript/components/operations/changeMaintenancePlan.js
+++ b/app/javascript/components/operations/changeMaintenancePlan.js
@@ -1,0 +1,15 @@
+const changeMaintenancePlan = () => {
+  const mpSelectList = document.getElementById("operation_maintenance_plan_id");
+  if (mpSelectList) {
+    function populateOpsFields() {
+      const mp = JSON.parse(this.value);
+      const opsTask = document.getElementById("operation_task");
+      const opsDetails = document.getElementById("operation_details");
+      opsTask.value = mp.task;
+      opsDetails.value = mp.details;
+    };
+    mpSelectList.addEventListener('change', populateOpsFields);
+  }
+};
+
+export {changeMaintenancePlan};

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -27,9 +27,11 @@ require("channels")
 // Internal imports, e.g:
 // import { initSelect2 } from '../components/init_select2';
 import { indexToggleDisplay } from '../components/shops/indexToggleDisplay';
+import { changeMaintenancePlan } from '../components/operations/changeMaintenancePlan';
 
 document.addEventListener('turbolinks:load', () => {
   // Call your functions here, e.g:
   // initSelect2();
   indexToggleDisplay();
+  changeMaintenancePlan();
 });

--- a/app/models/maintenance.rb
+++ b/app/models/maintenance.rb
@@ -1,4 +1,15 @@
 class Maintenance < ApplicationRecord
   belongs_to :vehicle
-  has_many :operations
+  has_many :operations, dependent: :destroy
+
+  validate :date_cannot_be_in_the_future
+  validates :km, presence: true, numericality: { greater_than: 0 }
+
+  private
+
+  def date_cannot_be_in_the_future
+    return unless date.present? && date.strftime > Date.today.strftime
+
+    errors.add(:date, "Une maintenance ne peut être créée dans le futur")
+  end
 end

--- a/app/models/operation.rb
+++ b/app/models/operation.rb
@@ -1,4 +1,6 @@
 class Operation < ApplicationRecord
   belongs_to :maintenance
   belongs_to :maintenance_plan, optional: true
+
+  validates :task, presence: true
 end

--- a/app/views/maintenance_plans/index.html.erb
+++ b/app/views/maintenance_plans/index.html.erb
@@ -37,5 +37,5 @@
 </div>
 
 <div>
-  <%= link_to "Retour", vehicle_path(params[:vehicle_id]) %>
+  <%= link_to "Retour", vehicle_path(@vehicle) %>
 </div>

--- a/app/views/maintenance_plans/index.html.erb
+++ b/app/views/maintenance_plans/index.html.erb
@@ -35,3 +35,7 @@
     <%= render "mp_edit" %>
   </div>
 </div>
+
+<div>
+  <%= link_to "Retour", vehicle_path(params[:vehicle_id]) %>
+</div>

--- a/app/views/maintenances/_m_edit.html.erb
+++ b/app/views/maintenances/_m_edit.html.erb
@@ -1,0 +1,7 @@
+<h3><%= "#{@btn_txt} une maintenance" %></h3>
+<%= simple_form_for [@vehicle, @maintenance] do |f| %>
+  <%= f.input :date %>
+  <%= f.input :km %>
+  <%= f.submit "Save" %>
+  <%= link_to "Cancel", vehicle_maintenances_path %>
+<% end %>

--- a/app/views/maintenances/_m_edit.html.erb
+++ b/app/views/maintenances/_m_edit.html.erb
@@ -2,6 +2,6 @@
 <%= simple_form_for [@vehicle, @maintenance] do |f| %>
   <%= f.input :date %>
   <%= f.input :km %>
-  <%= f.submit "Save" %>
-  <%= link_to "Cancel", vehicle_maintenances_path %>
+  <%= f.submit "#{@btn_txt}" %>
+  <%= link_to "Annuler", vehicle_maintenances_path %>
 <% end %>

--- a/app/views/maintenances/index.html.erb
+++ b/app/views/maintenances/index.html.erb
@@ -1,0 +1,26 @@
+<h2>Maintenances</h2>
+<div class="container">
+  <div class="list-ops">
+    <% if @maintenances %>
+      <% @maintenances.each do |maintenance| %>
+        <div class="list-el"> <!--display flex-->
+          <%= maintenance.date.strftime("%m/%d/%Y") %>
+          <%= "#{maintenance.km} km" %>
+          <%= pluralize(maintenance.nb_ops, "opération") %>
+          <%= link_to "Details", vehicle_maintenance_operations_path(params[:vehicle_id], maintenance) %>
+          | 
+          <%= link_to "Edit", edit_vehicle_maintenance_path(params[:vehicle_id], maintenance) %>
+          | 
+          <%= link_to "Del.", vehicle_maintenance_path(params[:vehicle_id], maintenance), method: :delete, remote: true %>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+  <div class="list-edit">
+    <%= render "m_edit" %>
+  </div>
+</div>
+
+<div>
+  <%= link_to "Retour", vehicle_path(params[:vehicle_id]) %>
+</div>

--- a/app/views/maintenances/index.html.erb
+++ b/app/views/maintenances/index.html.erb
@@ -7,11 +7,11 @@
           <%= maintenance.date.strftime("%m/%d/%Y") %>
           <%= "#{maintenance.km} km" %>
           <%= pluralize(maintenance.nb_ops, "opération") %>
-          <%= link_to "Details", vehicle_maintenance_operations_path(params[:vehicle_id], maintenance) %>
+          <%= link_to "Details", vehicle_maintenance_operations_path(@vehicle, maintenance) %>
           | 
-          <%= link_to "Edit", edit_vehicle_maintenance_path(params[:vehicle_id], maintenance) %>
+          <%= link_to "Edit", edit_vehicle_maintenance_path(@vehicle, maintenance) %>
           | 
-          <%= link_to "Del.", vehicle_maintenance_path(params[:vehicle_id], maintenance), method: :delete, remote: true %>
+          <%= link_to "Del.", vehicle_maintenance_path(@vehicle, maintenance), method: :delete, remote: true %>
         </div>
       <% end %>
     <% end %>
@@ -22,5 +22,5 @@
 </div>
 
 <div>
-  <%= link_to "Retour", vehicle_path(params[:vehicle_id]) %>
+  <%= link_to "Retour", vehicle_path(@vehicle) %>
 </div>

--- a/app/views/operations/_ops_edit.html.erb
+++ b/app/views/operations/_ops_edit.html.erb
@@ -1,0 +1,15 @@
+<h3><%= "#{@btn_txt} une opération" %></h3>
+<%= simple_form_for [@vehicle, @maintenance, @operation] do |f| %>
+  <%= f.association :maintenance_plan,
+    collection: MaintenancePlan.where(vehicle_id: params[:vehicle_id]).order(:task),
+    :label_method => lambda { |mp| "#{mp.task} | #{mp.interval_km} km | #{mp.interval_months} months" },
+    :value_method => lambda { |mp| mp.to_json },
+    prompt: "Sélectionner une maintenance type",
+    error:"Veuillez sélectionner la maintenance type à associer",
+    label:"Maintenance planifiée associée"
+  %>
+	<%= f.input :task %>
+  <%= f.input :details %>
+  <%= f.submit "Save" %>
+  <%= link_to "Cancel", vehicle_maintenance_operations_path %>
+<% end %>

--- a/app/views/operations/_ops_edit.html.erb
+++ b/app/views/operations/_ops_edit.html.erb
@@ -1,7 +1,7 @@
 <h3><%= "#{@btn_txt} une opération" %></h3>
 <%= simple_form_for [@vehicle, @maintenance, @operation] do |f| %>
   <%= f.association :maintenance_plan,
-    collection: MaintenancePlan.where(vehicle_id: params[:vehicle_id]).order(:task),
+    collection: MaintenancePlan.where(vehicle_id: @vehicle).order(:task),
     :label_method => lambda { |mp| "#{mp.task} | #{mp.interval_km} km | #{mp.interval_months} months" },
     :value_method => lambda { |mp| mp.to_json },
     prompt: "Sélectionner une maintenance type",
@@ -10,6 +10,6 @@
   %>
 	<%= f.input :task %>
   <%= f.input :details %>
-  <%= f.submit "Save" %>
-  <%= link_to "Cancel", vehicle_maintenance_operations_path %>
+  <%= f.submit "#{@btn_txt}" %>
+  <%= link_to "Annuler", vehicle_maintenance_operations_path %>
 <% end %>

--- a/app/views/operations/index.html.erb
+++ b/app/views/operations/index.html.erb
@@ -1,0 +1,25 @@
+<h2>Détails de la maintenance</h2>
+<%= "Réalisée le #{@maintenance.date.strftime("%d/%m/%Y")} à #{@maintenance.km} km " %>
+
+<div class="container">
+  <div class="list-ops">
+    <% if @operations %>
+      <% @operations.each do |operation| %>
+        <div class="list-el">
+          <div><%= operation.task %></div>
+          <div><%= operation.details %></div>
+          <%= link_to "Edit", edit_vehicle_maintenance_operation_path(params[:vehicle_id], operation.maintenance_id, operation) %>
+          | 
+          <div><%= link_to "Del.", vehicle_maintenance_operation_path(params[:vehicle_id], operation.maintenance_id, operation), method: :delete, remote: true %></div>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+  <div class="list-edit">
+    <%= render "ops_edit" %>
+  </div>
+</div>
+
+<div>
+  <%= link_to "Retour", vehicle_maintenances_path(params[:vehicle_id]) %>
+</div>

--- a/app/views/operations/index.html.erb
+++ b/app/views/operations/index.html.erb
@@ -8,9 +8,9 @@
         <div class="list-el">
           <div><%= operation.task %></div>
           <div><%= operation.details %></div>
-          <%= link_to "Edit", edit_vehicle_maintenance_operation_path(params[:vehicle_id], operation.maintenance_id, operation) %>
+          <%= link_to "Edit", edit_vehicle_maintenance_operation_path(@vehicle, @maintenance, operation) %>
           | 
-          <div><%= link_to "Del.", vehicle_maintenance_operation_path(params[:vehicle_id], operation.maintenance_id, operation), method: :delete, remote: true %></div>
+          <div><%= link_to "Del.", vehicle_maintenance_operation_path(@vehicle, @maintenance, operation), method: :delete, remote: true %></div>
         </div>
       <% end %>
     <% end %>
@@ -21,5 +21,5 @@
 </div>
 
 <div>
-  <%= link_to "Retour", vehicle_maintenances_path(params[:vehicle_id]) %>
+  <%= link_to "Retour", vehicle_maintenances_path(@vehicle) %>
 </div>

--- a/app/views/vehicles/show.html.erb
+++ b/app/views/vehicles/show.html.erb
@@ -16,4 +16,6 @@
 <br>
 <%= link_to "Plan de maintenance", vehicle_maintenance_plans_path(@vehicle) %>
 <br>
+<%= link_to "Maintenance", vehicle_maintenances_path(@vehicle) %>
+<br>
 <%= link_to "Accueil", vehicles_path %>


### PR DESCRIPTION
Maintenance#index includes the form to add/edit a maintenance.
Operation#index includes the form to add/edit an operation.
An operation can be link to a task from the maintenance plan or not.
When a MP is selected in the list, task and details of the operation are populated, and the default values can be updated if required.

Add a link from vehicle#show to maintenance#index.