### PR TITLE
Sale date and km validation rules

### DIFF
--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -26,7 +26,6 @@ class ShopsController < ApplicationController
 
   def update
     if @shop.update(shops_params)
-      @shop.save
       redirect_to shops_path, notice: "#{@shop.name} mis à jour"
     else
       @action = "Editer"

--- a/app/controllers/vehicles_controller.rb
+++ b/app/controllers/vehicles_controller.rb
@@ -20,7 +20,7 @@ class VehiclesController < ApplicationController
     @vehicle.user = user
 
     if @vehicle.save
-      redirect_to vehicles_path, notice: "Vehicle successfully created"
+      redirect_to vehicle_path(@vehicle), notice: "Vehicle successfully created"
     else
       @action = "Ajouter"
       render :new
@@ -34,7 +34,7 @@ class VehiclesController < ApplicationController
   def update
     if @vehicle.update(vehicle_params)
       @vehicle.save
-      redirect_to vehicles_path, notice: "Vehicle successfully updated"
+      redirect_to vehicle_path(@vehicle), notice: "Vehicle successfully updated"
     else
       @action = "Editer"
       render :edit

--- a/app/controllers/vehicles_controller.rb
+++ b/app/controllers/vehicles_controller.rb
@@ -33,7 +33,6 @@ class VehiclesController < ApplicationController
 
   def update
     if @vehicle.update(vehicle_params)
-      @vehicle.save
       redirect_to vehicle_path(@vehicle), notice: "Vehicle successfully updated"
     else
       @action = "Editer"

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -8,4 +8,22 @@ class Vehicle < ApplicationRecord
   has_many :reminders
   has_many :vehicle_fuels
   has_one_attached :photo
+
+  validates :sale_km, numericality: { greater_than: :purchase_km }, allow_nil: true
+  validate :sale_date_after_purchase_date
+  validate :sale_date_cannot_be_in_the_future
+
+  private
+
+  def sale_date_after_purchase_date
+    return if sale_date.blank? || purchase_date.blank?
+
+    errors.add(:sale_date, " ne peut pas être inférieure à la date d'achat") if sale_date < purchase_date
+  end
+
+  def sale_date_cannot_be_in_the_future
+    return unless sale_date.present? && sale_date.strftime > Date.today.strftime
+
+    errors.add(:sale_date, " ne peut pas être dans le futur")
+  end
 end

--- a/app/views/vehicles/_vehicle.html.erb
+++ b/app/views/vehicles/_vehicle.html.erb
@@ -10,7 +10,7 @@
 	<%= f.input :total_expenses %>
 	<%= f.input :purchase_date %>
 	<%= f.input :purchase_km %>
-	<%= f.input :sale_date %>
+	<%= f.input :sale_date, include_blank: true %>
 	<%= f.input :sale_km %>
 	<%= f.submit @action %>
 	<%= link_to "Annuler", vehicles_path %>


### PR DESCRIPTION
Sale_date can't be lower than the purchase_date nor in the future.
Sale_km can't be lower than purchase_km.
Change redirection for methods create and update (to vehicle#show instead of vehicle#index).